### PR TITLE
Fix download link for ConvertRequestButton

### DIFF
--- a/site/src/ConvertRequestButton.tsx
+++ b/site/src/ConvertRequestButton.tsx
@@ -63,7 +63,7 @@ export const ConvertRequestButton: React.FC<IConvertRequestButtonProps> = (props
         <div>
           Received JSON data:
           <pre>{JSON.stringify(responseData, null, 2)}</pre>
-          Go here to get your file: <a href={API_URL + responseData.file_name!!}>Download</a>
+          Go here to get your file: <a href={API_URL + (responseData.file_name ?? "")}>Download</a>
         </div>
         :
         <form>


### PR DESCRIPTION
## Summary
- fix ConvertRequestButton to concatenate filename safely

## Testing
- `npm run test` *(fails: react-scripts not found)*
- `bun x react-scripts test --watchAll=false` *(fails: ConnectionRefused downloading package manifest react-scripts)*